### PR TITLE
pdf, text(url), subject UI 추가

### DIFF
--- a/SubToQuiz.py
+++ b/SubToQuiz.py
@@ -9,13 +9,11 @@ from langchain.chains import LLMChain
 from langchain_openai import ChatOpenAI
 from langchain.pydantic_v1 import BaseModel, Field
 
-
 class QuizMultipleChoice(BaseModel):
     quiz_text: str = Field(description="The quiz test")
     questions: List[str] = Field(description="The quiz quesitons")
     alternatives: List[List[str]] = Field(description="The quiz alternatives")
     answers: List[str] = Field(description="The quiz answers")
-
 
 class QuizTrueFalse(BaseModel):
     quiz_text: str = Field(description="The quiz test")
@@ -23,26 +21,22 @@ class QuizTrueFalse(BaseModel):
     alternatives: List[List[str]] = Field(description="The quiz alternatives")
     answers: List[str] = Field(description="The quiz answers")
 
-
 class QuizOpenEnded(BaseModel):
     questions: List[str] = Field(description="The quiz quesitons")
     answers: List[str] = Field(description="The quiz answers")
-
 
 def create_quiz_chain(prompt_template, llm, pydantic_object_schema):
     """Creates the chain for the quiz app."""
     return prompt_template | llm.with_structured_output(pydantic_object_schema)
 
-
-def create_multiple_choice_template():
-    """Create the prompt template for the quiz app."""
-
+def create_multiple_choice_template(language):
+    """Create the prompt template for the quiz app, including conditional translation."""
     template = """ 
     You are an expert quiz maker for technical fields. Let's think step by step and
-    create a quiz with {num_questions} questions about the following concept/content: {quiz_context}.
+    create a quiz with {num_questions} multiple-choice questions about the following concept/content: {quiz_context}.
 
-    The format of the quiz could be one of the following:
-
+    The format of the quiz should be as follows:
+    
     - Multiple-choice: 
     - Questions:
         <Question1>: 
@@ -58,13 +52,19 @@ def create_multiple_choice_template():
         ....
         <AnswerN>: <option 1 | option 2 | option 3 | option 4>
     """
+
+    # Conditionally add translation instruction based on the selected language
+    if language != "English":
+        template += f"\n\nPlease ensure that the quiz is accurately translated into {language}, maintaining the technical accuracy and clarity of the questions and options."
+
     prompt = ChatPromptTemplate.from_template(template)
     return prompt
 
 
-def create_true_false_template():
-    """Create the prompt template for the quiz app."""
 
+def create_true_false_template(language):
+    """Create the prompt template for the quiz app."""
+    
     template = """
     You are an expert quiz maker for technical fields. Let's think step by step and
     create a quiz with {num_questions} questions about the following concept/content: {quiz_context}.
@@ -86,11 +86,14 @@ def create_true_false_template():
         .....
         <AnswerN>: <True|False>
     """
+    # Conditionally add translation instruction based on the selected language
+    if language != "English":
+        template += f"\n\nPlease ensure that the quiz is accurately translated into {language}, maintaining the technical accuracy and clarity of the questions and options."
+
     prompt = ChatPromptTemplate.from_template(template)
     return prompt
 
-
-def create_open_ended_template():
+def create_open_ended_template(language):
     template = """
     You are an expert quiz maker for technical fields. Let's think step by step and
     create a quiz with {num_questions} questions about the following concept/content: {quiz_context}.
@@ -107,19 +110,23 @@ def create_open_ended_template():
         <Answer2>:
         .....
         <AnswerN>:
-
+       
     """
+    # Conditionally add translation instruction based on the selected language
+    if language != "English":
+        template += f"\n\nPlease ensure that the quiz is accurately translated into {language}, maintaining the technical accuracy and clarity of the questions and options."
+
     prompt = ChatPromptTemplate.from_template(template)
     return prompt
-
 
 def main():
     st.title("Quiz App")
     st.write("This app generates a quiz based on a given context.")
-    llm = ChatOpenAI()
+    llm = ChatOpenAI(model="gpt-4-turbo")
     context = st.text_area("Enter the concept/context for the quiz")
     num_questions = st.number_input("Enter the number of questions", min_value=1, max_value=10, value=3)
     quiz_type = st.selectbox("Select the quiz type", ["multiple-choice", "true-false", "open-ended"])
+    language = st.selectbox("Select the translation language",  ["English", "korean", "Spanish", "French"])  # 언어 선택
 
     # 퀴즈 유형 변경 시 상태 초기화
     if 'quiz_type' not in st.session_state or st.session_state.quiz_type != quiz_type:
@@ -127,21 +134,23 @@ def main():
         st.session_state.quiz_data = None
         st.session_state.user_answers = None
 
+
     if st.button("Generate Quiz"):
         if quiz_type == "multiple-choice":
-            prompt_template = create_multiple_choice_template()
+            prompt_template = create_multiple_choice_template(language)
             pydantic_object_schema = QuizMultipleChoice
         elif quiz_type == "true-false":
-            prompt_template = create_true_false_template()
+            prompt_template = create_true_false_template(language)
             pydantic_object_schema = QuizTrueFalse
         else:
-            prompt_template = create_open_ended_template()
+            prompt_template = create_open_ended_template(language)
             pydantic_object_schema = QuizOpenEnded
 
+        st.write("에러가 발생할 경우, 다시 생성버튼을 눌러주시면 됩니다 ㅎㅎ")
         chain = create_quiz_chain(prompt_template, llm, pydantic_object_schema)
         st.session_state.quiz_data = chain.invoke({"num_questions": num_questions, "quiz_context": context})
-        st.session_state.user_answers = [None] * len(
-            st.session_state.quiz_data.questions) if st.session_state.quiz_data else []
+        st.session_state.user_answers = [None] * len(st.session_state.quiz_data.questions) if st.session_state.quiz_data else []
+
 
     if 'quiz_data' in st.session_state and st.session_state.quiz_data:
         user_answers = {}
@@ -149,12 +158,11 @@ def main():
             st.write(f"**{idx + 1}. {question}**")
             if quiz_type != "open-ended":
                 options = st.session_state.quiz_data.alternatives[idx]
-                # 선택지에 라벨을 추가하지 않고, 직접 사용합니다.
-                formatted_options = {option: option for option in options}
-                user_answer_key = st.radio("Select an answer:", list(formatted_options.keys()), key=idx)
-                user_answers[idx] = user_answer_key  # 직접 'True' 또는 'False'를 저장합니다.
+                user_answer_key = st.radio("Select an answer:", options, key=idx)
+                user_answers[idx] = user_answer_key
             else:
                 user_answers[idx] = st.text_area("Your answer:", key=idx)
+
         if st.button("Score Quiz"):
             score = 0
             correct_answers = []
@@ -172,3 +180,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/pages/PdfToQuiz.py
+++ b/pages/PdfToQuiz.py
@@ -1,15 +1,25 @@
 import streamlit as st
+import os
 from dotenv import load_dotenv
+load_dotenv()
+
+from typing import List
 from PyPDF2 import PdfReader
 from langchain.text_splitter import CharacterTextSplitter
-from langchain.embeddings import OpenAIEmbeddings
-from langchain.vectorstores import FAISS
-from langchain.chat_models import ChatOpenAI
-from langchain.memory import ConversationBufferMemory
-from langchain.chains import ConversationalRetrievalChain
-from htmlTemplates import css, bot_template
-import openai
+from langchain_community.embeddings import OpenAIEmbeddings
+from langchain_community.vectorstores import FAISS
+from langchain.prompts import ChatPromptTemplate
+from langchain.chains import LLMChain
+from langchain_openai import ChatOpenAI
+from langchain.pydantic_v1 import BaseModel, Field
 
+import numpy as np
+import sys
+sys.path.append('../')  # 상위 폴더를 시스템 경로에 추가
+from SubToQuiz import QuizMultipleChoice, QuizTrueFalse, QuizOpenEnded, create_quiz_chain, create_multiple_choice_template, create_true_false_template, create_open_ended_template
+from htmlTemplates import css, bot_template
+
+    # PDF 텍스트 추출
 def get_pdf_text(pdf_docs):
     text = ""
     for pdf in pdf_docs:
@@ -18,7 +28,7 @@ def get_pdf_text(pdf_docs):
             text += page.extract_text()
     return text
 
-
+# 텍스트를 청크로 분할
 def get_text_chunks(text):
     text_splitter = CharacterTextSplitter(
         separator="\n",
@@ -29,143 +39,43 @@ def get_text_chunks(text):
     chunks = text_splitter.split_text(text)
     return chunks
 
-
+# 벡터스토어 생성
 def get_vectorstore(text_chunks):
     embeddings = OpenAIEmbeddings()
     vectorstore = FAISS.from_texts(texts=text_chunks, embedding=embeddings)
     return vectorstore
 
-
-def get_conversation_chain(vectorstore):
-    llm = ChatOpenAI()
-
-    memory = ConversationBufferMemory(
-        memory_key='chat_history', return_messages=True)
-    conversation_chain = ConversationalRetrievalChain.from_llm(
-        llm=llm,
-        retriever=vectorstore.as_retriever(),
-        memory=memory
-    )
-    return conversation_chain
-
-
-def handle_userinput(user_question):
-    response = st.session_state.conversation({'question': user_question})
-
-    st.session_state.chat_history = response['chat_history']
-
-    for i, message in enumerate(st.session_state.chat_history):
-        if i % 2 == 0:
-            pass
-        else:
-            st.write(message.content)
-
-def on_multiple_button_click():
-    user_question = " Create multiple-choice questions and answers, and translate korean, only prints korean. "
-    handle_userinput(user_question)
-
-
-def on_short_answer_button_click():
-    user_question = "Create short questions and answers, and translate korean, only prints korean."
-    handle_userinput(user_question)
-
-
-def on_true_false_button_click():
-    user_question = "Create true of false questions and answers, and translate korean, only prints korean. "
-    handle_userinput(user_question)
-
-
-def on_blanks_button_click():
-    user_question = "Create fill-in-the-blank questions and answers, and translate korean, only prints korean. The blanks should represent missing words or phrases in the questions, to be filled in by the reader."
-    handle_userinput(user_question)
-
-
-def on_multiple_button_click_eng():
-    user_question = " Generate multiple-choice questions based on the given concept."
-    handle_userinput(user_question)
-
-
-def on_short_answer_button_click_eng():
-    user_question = "Generate short-answer questions based on the given concept."
-    handle_userinput(user_question)
-
-
-def on_true_false_button_click_eng():
-    user_question = "Create true or false questions and answers based on the given concept. "
-    handle_userinput(user_question)
-
-
-def on_blanks_button_click_eng():
-    user_question = "Generate blanks questions based on the given concept."
-    handle_userinput(user_question)
+# 청크 선택 알고리즘 
+def select_chunk_set(vectorstore, text_chunks, num_vectors=5):
+    # 구현의 편의를 위해 앞쪽 5개의 텍스트 가져옴
+    chunks = text_chunks[:5]
+    # 선택된 텍스트 청크들을 하나의 문자열로 결합
+    context = ' '.join(chunks)
+    return context
 
 
 def main():
-
-    load_dotenv()
     st.set_page_config(page_title="PDF 기반 문제 생성",
                        page_icon=":books:")
     st.write(css, unsafe_allow_html=True)
 
-    if "conversation" not in st.session_state:
-        st.session_state.conversation = None
-    if "chat_history" not in st.session_state:
-        st.session_state.chat_history = None
-
     st.header("퀴즈 생성기 :books:")
     st.caption("파일 업로드 후 원하시는 문제를 선택하여 주십시오. ")
 
-    lang = st.radio(
+    language = st.radio(
         "언어 선택",
-        ["영어","한국어"],
+        ["English", "한국어", "Spanish", "French"],
     )
-    type = st.radio(
+    quiz_type = st.radio(
         "종류 선택",
-        ["객관식", "주관식", "참/거짓", "빈칸 맞추기"],
+        ["multiple-choice", "true-false", "open-ended"],
     )
+    num_questions = st.number_input("Enter the number of questions", min_value=1, max_value=10, value=3)
+    llm = ChatOpenAI(model="gpt-4-turbo")
 
-    if lang == '한국어':
-        if type == '객관식':
-            if st.button('생성'):
-                st.session_state.chat_history = None
-                on_multiple_button_click()
-
-        if type == '주관식':
-            if st.button('생성'):
-                st.session_state.chat_history = None
-                on_short_answer_button_click()
-
-        if type == '참/거짓':
-            if st.button('생성'):
-                st.session_state.chat_history = None
-                on_true_false_button_click()
-
-        if type == '빈칸 맞추기':
-            if st.button('생성'):
-                st.session_state.chat_history = None
-                on_blanks_button_click()
-
-    if lang == '영어':
-        if type == '객관식':
-            if st.button('생성'):
-                st.session_state.chat_history = None
-                on_multiple_button_click_eng()
-
-        if type == '주관식':
-            if st.button('생성'):
-                st.session_state.chat_history = None
-                on_short_answer_button_click_eng()
-
-        if type == '참/거짓':
-            if st.button('생성'):
-                st.session_state.chat_history = None
-                on_true_false_button_click_eng()
-
-        if type == '빈칸 맞추기':
-            if st.button('생성'):
-                st.session_state.chat_history = None
-                on_blanks_button_click_eng()
-
+    if "context" not in st.session_state:
+        st.session_state.context = None  # context 초기화
+        
     with st.sidebar:
         st.subheader("문서 업로드")
         pdf_docs = st.file_uploader(
@@ -178,10 +88,64 @@ def main():
 
                 vectorstore = get_vectorstore(text_chunks)
 
-                st.session_state.conversation = get_conversation_chain(vectorstore)
+                st.session_state.context = select_chunk_set(vectorstore, text_chunks)
 
                 st.success('저장 완료!', icon="✅")
 
+    
+    # 퀴즈 유형 변경 시 상태 초기화
+    if 'quiz_type' not in st.session_state or st.session_state.quiz_type != quiz_type:
+        st.session_state.quiz_type = quiz_type
+        st.session_state.quiz_data = None
+        st.session_state.user_answers = None
 
-if __name__ == '__main__':
+
+    if st.button("Generate Quiz"):
+        if st.session_state.context:
+            if quiz_type == "multiple-choice":
+                prompt_template = create_multiple_choice_template(language)
+                pydantic_object_schema = QuizMultipleChoice
+            elif quiz_type == "true-false":
+                prompt_template = create_true_false_template(language)
+                pydantic_object_schema = QuizTrueFalse
+            else:
+                prompt_template = create_open_ended_template(language)
+                pydantic_object_schema = QuizOpenEnded
+
+            st.write("에러가 발생할 경우, 다시 생성버튼을 눌러주시면 됩니다 ㅎㅎ")
+            chain = create_quiz_chain(prompt_template, llm, pydantic_object_schema)
+            st.session_state.quiz_data = chain.invoke({"num_questions": num_questions, "quiz_context": st.session_state.context})
+            st.session_state.user_answers = [None] * len(st.session_state.quiz_data.questions) if st.session_state.quiz_data else []
+        else:
+            st.write("pdf파일을 왼쪽 슬라이드에 올리고 벡터 변환해주세요")
+
+
+    if 'quiz_data' in st.session_state and st.session_state.quiz_data:
+        user_answers = {}
+        for idx, question in enumerate(st.session_state.quiz_data.questions):
+            st.write(f"**{idx + 1}. {question}**")
+            if quiz_type != "open-ended":
+                options = st.session_state.quiz_data.alternatives[idx]
+                user_answer_key = st.radio("Select an answer:", options, key=idx)
+                user_answers[idx] = user_answer_key
+            else:
+                user_answers[idx] = st.text_area("Your answer:", key=idx)
+
+        if st.button("Score Quiz"):
+            score = 0
+            correct_answers = []
+            for idx, question in enumerate(st.session_state.quiz_data.questions):
+                correct_answer = st.session_state.quiz_data.answers[idx]
+                if quiz_type != "open-ended":
+                    if user_answers[idx] == correct_answer:
+                        score += 1
+                correct_answers.append(f"{idx + 1}. {correct_answer}")
+            st.write("Quiz results:")
+            st.write(f"Your score: {score}/{len(st.session_state.quiz_data.questions)}")
+            for correct_answer in correct_answers:
+                st.write(correct_answer)
+
+
+if __name__ == "__main__":
     main()
+

--- a/pages/TextToQuiz.py
+++ b/pages/TextToQuiz.py
@@ -1,118 +1,182 @@
 import streamlit as st
-from langchain_core.messages import AIMessage, HumanMessage
+import os
+from dotenv import load_dotenv
+load_dotenv()
+
+from typing import List
 from langchain_community.document_loaders import WebBaseLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import Chroma
 from langchain_openai import OpenAIEmbeddings, ChatOpenAI
-from dotenv import load_dotenv
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.prompts import ChatPromptTemplate
 from langchain.chains import create_history_aware_retriever, create_retrieval_chain
 from langchain.chains.combine_documents import create_stuff_documents_chain
+from langchain.chains import LLMChain
+from langchain.pydantic_v1 import BaseModel, Field
 
-load_dotenv()
+import sys
+sys.path.append('../')  # 상위 폴더를 시스템 경로에 추가
+from SubToQuiz import QuizMultipleChoice, QuizTrueFalse, QuizOpenEnded, create_quiz_chain, create_multiple_choice_template, create_true_false_template, create_open_ended_template
+from htmlTemplates import css
+
 
 ##임시 업로드용 파일 TextToQuiz 구현 후 대체 해야함.
 
-
-def get_vectorstore_from_url(url):
-    # get the text in document form
+def get_text_from_url(url):
     loader = WebBaseLoader(url)
     document = loader.load()
+    return document
 
-    # split the document into chunks
+def process_text_to_chunks(text):
     text_splitter = RecursiveCharacterTextSplitter()
-    document_chunks = text_splitter.split_documents(document)
+    document_chunks = text_splitter.split_documents(text)
+    return document_chunks
 
-    # create a vectorstore from the chunks
-    vector_store = Chroma.from_documents(document_chunks, OpenAIEmbeddings())
-
+def create_vector_store(chunks):
+    embeddings = OpenAIEmbeddings()
+    vector_store = Chroma.from_documents(chunks, embeddings)
     return vector_store
 
-
-def get_context_retriever_chain(vector_store):
-    llm = ChatOpenAI()
-
-    retriever = vector_store.as_retriever()
-
-    prompt = ChatPromptTemplate.from_messages([
-        MessagesPlaceholder(variable_name="chat_history"),
-        ("user", "{input}"),
-        ("user",
-         "Given the above conversation, generate a search query to look up in order to get information relevant to the conversation")
-    ])
-
-    retriever_chain = create_history_aware_retriever(llm, retriever, prompt)
-
-    return retriever_chain
+def select_chunk_set(vectorstore, text_chunks, num_vectors=5):
+    # 구현의 편의를 위해 앞쪽 5개의 텍스트 가져옴
+    chunks = text_chunks[:5]
+    # 선택된 텍스트 청크들을 하나의 문자열로 결합
+    context = ' '.join(chunk.page_content for chunk in chunks)
+    return context
 
 
-def get_conversational_rag_chain(retriever_chain):
-    llm = ChatOpenAI()
+# def get_context_retriever_chain(vector_store):
+#     llm = ChatOpenAI()
 
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", "Answer the user's questions based on the below context:\n\n{context}"),
-        MessagesPlaceholder(variable_name="chat_history"),
-        ("user", "{input}"),
-    ])
+#     retriever = vector_store.as_retriever()
 
-    stuff_documents_chain = create_stuff_documents_chain(llm, prompt)
+#     prompt = ChatPromptTemplate.from_messages([
+#         MessagesPlaceholder(variable_name="chat_history"),
+#         ("user", "{input}"),
+#         ("user",
+#          "Given the above conversation, generate a search query to look up in order to get information relevant to the conversation")
+#     ])
 
-    return create_retrieval_chain(retriever_chain, stuff_documents_chain)
+#     retriever_chain = create_history_aware_retriever(llm, retriever, prompt)
 
-
-
-def get_response(user_input):
-    retriever_chain = get_context_retriever_chain(st.session_state.vector_store)
-    conversation_rag_chain = get_conversational_rag_chain(retriever_chain)
-
-    response = conversation_rag_chain.invoke({
-        "chat_history": st.session_state.chat_history,
-        "input": user_input
-    })
-
-    return response['answer']
+#     return retriever_chain
 
 
-# app config
-st.set_page_config(page_title="사이트 기반 문제 생성", page_icon="🤖")
-st.title("사이트 기반 문제 생성")
+# def get_conversational_rag_chain(retriever_chain):
+#     llm = ChatOpenAI()
 
-# sidebar
-with st.sidebar:
-    st.header("URL 입력 후 엔터를 눌러 주십시오.")
-    website_url = st.text_input("Website URL")
+#     prompt = ChatPromptTemplate.from_messages([
+#         ("system", "Answer the user's questions based on the below context:\n\n{context}"),
+#         MessagesPlaceholder(variable_name="chat_history"),
+#         ("user", "{input}"),
+#     ])
 
-    if website_url:
-        st.session_state.chat_history = [
-            #AIMessage(content="Hello, I am a bot. How can I help you?"),
-        ]
+#     stuff_documents_chain = create_stuff_documents_chain(llm, prompt)
 
-if website_url is None or website_url == "":
-    st.info("Please enter a website URL")
+#     return create_retrieval_chain(retriever_chain, stuff_documents_chain)
 
-else:
-    # session state
-    if "chat_history" not in st.session_state:
-        st.session_state.chat_history = [
-            #AIMessage(content="Hello, I am a bot. How can I help you?"),
-        ]
 
-    if "vector_store" not in st.session_state:
-        st.session_state.vector_store = get_vectorstore_from_url(website_url)
 
-        # user input
-    #user_query = st.chat_input("Type your message here...")
-    user_query = "create quiz about this site."
-    if user_query is not None and user_query != "":
-        response = get_response(user_query)
-        st.session_state.chat_history.append(HumanMessage(content=user_query))
-        st.session_state.chat_history.append(AIMessage(content=response))
+# def get_response(user_input):
+#     retriever_chain = get_context_retriever_chain(st.session_state.vector_store)
+#     conversation_rag_chain = get_conversational_rag_chain(retriever_chain)
 
-    # conversation
-    for message in st.session_state.chat_history:
-        if isinstance(message, AIMessage):
-            with st.chat_message("AI"):
-                st.session_state.script = message.content
-                st.text_area("Generated quiz", st.session_state.script, height=500)
-        elif isinstance(message, HumanMessage):
-            pass
+#     response = conversation_rag_chain.invoke({
+#         "chat_history": st.session_state.chat_history,
+#         "input": user_input
+#     })
+
+#     return response['answer']
+
+def main():
+    # app config
+    st.set_page_config(page_title="사이트 기반 문제 생성", page_icon="🤖")
+    st.write(css, unsafe_allow_html=True)
+    st.header("퀴즈 생성기 :url:")
+    st.caption("url 입력후 원하시는 문제를 선택하여 주십시오. ")
+
+    language = st.radio(
+            "언어 선택",
+            ["English", "한국어", "Spanish", "French"],
+        )
+    quiz_type = st.radio(
+            "종류 선택",
+            ["multiple-choice", "true-false", "open-ended"],
+        )
+    num_questions = st.number_input("Enter the number of questions", min_value=1, max_value=10, value=3)
+    llm = ChatOpenAI(model="gpt-4-turbo")
+
+    if "context" not in st.session_state:
+        st.session_state.context = None  # context 초기화
+
+    # sidebar
+    with st.sidebar:
+        st.header("URL 입력 후 엔터를 눌러 주십시오.")
+        website_url = st.text_input("Website URL")
+
+        if st.button("벡터 변환"):
+            with st.spinner("변환 중"):
+                raw_text = get_text_from_url(website_url)
+
+                text_chunks = process_text_to_chunks(raw_text)
+
+                vectorstore = create_vector_store(text_chunks)
+
+                st.session_state.context = select_chunk_set(vectorstore, text_chunks)
+
+                st.success('저장 완료!', icon="✅")
+
+    # 퀴즈 유형 변경 시 상태 초기화
+    if 'quiz_type' not in st.session_state or st.session_state.quiz_type != quiz_type:
+        st.session_state.quiz_type = quiz_type
+        st.session_state.quiz_data = None
+        st.session_state.user_answers = None
+
+    if st.button("Generate Quiz"):
+        if st.session_state.context:
+            if quiz_type == "multiple-choice":
+                prompt_template = create_multiple_choice_template(language)
+                pydantic_object_schema = QuizMultipleChoice
+            elif quiz_type == "true-false":
+                prompt_template = create_true_false_template(language)
+                pydantic_object_schema = QuizTrueFalse
+            else:
+                prompt_template = create_open_ended_template(language)
+                pydantic_object_schema = QuizOpenEnded
+
+            st.write("에러가 발생할 경우, 다시 생성버튼을 눌러주시면 됩니다 ㅎㅎ")
+            chain = create_quiz_chain(prompt_template, llm, pydantic_object_schema)
+            st.session_state.quiz_data = chain.invoke({"num_questions": num_questions, "quiz_context": st.session_state.context})
+            st.session_state.user_answers = [None] * len(st.session_state.quiz_data.questions) if st.session_state.quiz_data else []
+        else:
+            st.write("url을 왼쪽 슬라이드에 입력하고 벡터 변환해주세요")
+
+
+    if 'quiz_data' in st.session_state and st.session_state.quiz_data:
+        user_answers = {}
+        for idx, question in enumerate(st.session_state.quiz_data.questions):
+            st.write(f"**{idx + 1}. {question}**")
+            if quiz_type != "open-ended":
+                options = st.session_state.quiz_data.alternatives[idx]
+                user_answer_key = st.radio("Select an answer:", options, key=idx)
+                user_answers[idx] = user_answer_key
+            else:
+                user_answers[idx] = st.text_area("Your answer:", key=idx)
+
+        if st.button("Score Quiz"):
+            score = 0
+            correct_answers = []
+            for idx, question in enumerate(st.session_state.quiz_data.questions):
+                correct_answer = st.session_state.quiz_data.answers[idx]
+                if quiz_type != "open-ended":
+                    if user_answers[idx] == correct_answer:
+                        score += 1
+                correct_answers.append(f"{idx + 1}. {correct_answer}")
+            st.write("Quiz results:")
+            st.write(f"Your score: {score}/{len(st.session_state.quiz_data.questions)}")
+            for correct_answer in correct_answers:
+                st.write(correct_answer)
+
+        
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
새로운 점
- pdf의 경우에는 빈칸형 템플릿이 없어서 유형 삭제
-  언어 추가
-  gpt4 사용하면서 출력의 변동성 사라짐 (에러 x)
- 모든 page에서 같은 템플릿을 사용함

문제점
- 언어 번역이 안될 때가 있음 
-  pdf, url의 경우 모든 청크를 이용하지 않고 앞의 5개 청크만 사용해서 퀴즈를 생성하고 있음 (추후 청크 선택 알고리즘 고민)
즉, 벡터 저장소로 변환은 하고 있으나 실질적으로 사용하고 있지는 않음 (RAG기반이 아니므로)
- 코드의 가독성이 떨어짐 (streamllit 숙련도 이슈)

